### PR TITLE
fixed improper permission for `auto-import.sh`

### DIFF
--- a/docker/root/etc/crontabs/abc
+++ b/docker/root/etc/crontabs/abc
@@ -1,2 +1,0 @@
-# min   hour    day     month   weekday command
-*/5     *       *       *       *       /app/auto-import.sh

--- a/docker/root/etc/s6-overlay/s6-rc.d/init-posteria-config/run
+++ b/docker/root/etc/s6-overlay/s6-rc.d/init-posteria-config/run
@@ -1,7 +1,7 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# symlink config folders
+# Symlink config folders
 for dir in posters data; do
     mkdir -p "/config/${dir}"
     if [ "$(readlink /app/www/public/${dir})" != "/config/${dir}" ]; then
@@ -11,7 +11,7 @@ for dir in posters data; do
     fi
 done
 
-# create posters sub-folders
+# Create posters sub-folders
 mkdir -p \
     /config/posters/movies \
     /config/posters/tv-shows \
@@ -27,3 +27,22 @@ sed -i 's/^/export /' /app/docker-env.sh
 # Proper permission for scripts
 chmod +x /app/www/public/include/*.sh
 chmod +x /app/*.sh
+
+# Setup auto import scheduling based on AUTO_IMPORT_SCHEDULE value
+if [ -z "$AUTO_IMPORT_SCHEDULE" ]; then
+    echo "AUTO_IMPORT_SCHEDULE not set, skipping auto import schedule setup."
+else
+    case "$AUTO_IMPORT_SCHEDULE" in
+        "24h") cron_expr="0 0 * * *"; human_description="At Midnight" ;;
+        "12h") cron_expr="0 */12 * * *"; human_description="Every 12 hours" ;;
+        "6h")  cron_expr="0 */6 * * *"; human_description="Every 6 hours" ;;
+        "3h")  cron_expr="0 */3 * * *"; human_description="Every 3 hours" ;;
+        "1h")  cron_expr="0 * * * *"; human_description="Every hour" ;;
+        *)     cron_expr="0 * * * *"; human_description="Every hour (Invalid value AUTO_IMPORT_SCHEDULE=\"$AUTO_IMPORT_SCHEDULE\", falling back to default)" ;; # fallback to 24h
+    esac
+    echo "$cron_expr /app/auto-import.sh" > /etc/crontabs/abc
+    echo "Setting up auto import schedule: $human_description (cron expression='$cron_expr')"
+fi
+
+# Remove default root's crontab jobs
+rm /etc/crontabs/root


### PR DESCRIPTION
Improve file ownership handling and error reporting

- Addresses most permission-related scenarios
- Warns users about potential application functionality issues due to permission constraints

When ownership changes fail (typically with root-level files or read-only volumes), the system will now log a detailed message:

```log
chown: changing ownership of '/config/data/auto-import.log': Permission denied
**** Permissions could not be set. This is probably because your volume mounts are remote or read-only. ****
**** The app may not work properly and we will not provide support for it. ****
```

In case of ownership changes failing, two actions can be performed by the user:
- Manually change ownership using `chmod xxxx:yyyy /path/to/problematic.file` (where `xxxx` matches `PUID` value and `yyyy` matches `PGID`)
- Delete the problematic file manually if it's not critical

Resolves #56